### PR TITLE
Modified text for landingPage to reflect the new spec for that field

### DIFF
--- a/src/components/forms/DistributionForm/DistributionForm.jsx
+++ b/src/components/forms/DistributionForm/DistributionForm.jsx
@@ -81,7 +81,7 @@ export default function DistributionForm(props) {
         <SectionTitle
           subsection
           name='Landing Page'
-          tooltip='A URL (Web page) that contains information about the associated dataset (with a link to the dataset) or a direct link to the dataset itself. When none exists yet, please provide the link to the GitHub repository hosting the CONP DataLad dataset.'
+          tooltip='A URL (Web page) that contains information about the associated dataset (with a link to the dataset) or a direct link to the dataset itself. When none exists yet, please provide the link to the README.md file of the dataset.'
         />
         <CustomTextField label='Landing Page' name='access.landingPage' />
         <SectionTitle

--- a/src/components/forms/DistributionForm/DistributionForm.jsx
+++ b/src/components/forms/DistributionForm/DistributionForm.jsx
@@ -81,7 +81,7 @@ export default function DistributionForm(props) {
         <SectionTitle
           subsection
           name='Landing Page'
-          tooltip='A URL (Web page) that contains information about the associated dataset (with a link to the dataset) or a direct link to the dataset itself.'
+          tooltip='A URL (Web page) that contains information about the associated dataset (with a link to the dataset) or a direct link to the dataset itself. When none exists yet, please provide the link to the GitHub repository hosting the CONP DataLad dataset.'
         />
         <CustomTextField label='Landing Page' name='access.landingPage' />
         <SectionTitle


### PR DESCRIPTION
As of the CONP dev meeting on Nov 18 2020, we are instituting a policy that the default value for distributions-access-landingPage, in cases where the user does not supply one, should be a URL pointing to the README.md for their dataset.

This PR updates the GUI instructions for that field to reflect this spec.

https://github.com/CONP-PCNO/conp-dats-editor/issues/23

![Screen Shot 2021-04-07 at 4 54 37 PM](https://user-images.githubusercontent.com/1402456/113933094-2a0ee180-97c2-11eb-9598-1f8e7a1b5d59.png)

