### PR TITLE
Remove description empty field from the dates of primaryPublications

### DIFF
--- a/src/components/forms/ExtraPropertiesForm/ExtraPropertiesForm.jsx
+++ b/src/components/forms/ExtraPropertiesForm/ExtraPropertiesForm.jsx
@@ -266,7 +266,6 @@ export default function ExtraPropertiesForm(props) {
                                 color='secondary'
                                 onClick={() => {
                                   arrayHelpers.push({
-                                    description: '',
                                     date: new Date(
                                       new Date().setHours(0, 0, 0, 0)
                                     )


### PR DESCRIPTION
Remove the wrongly added "description" field to the dates of primary publication when creating the  DATS.json file. 


This resolves #27 