### PR TITLE
Fix naming of the generated DATS file and the weird creator bug found when editing an existing DATS file

### DIFF
--- a/src/components/CreateDatsSuccess/CreateDatsSuccess.jsx
+++ b/src/components/CreateDatsSuccess/CreateDatsSuccess.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Button, Typography } from '@material-ui/core'
-import { format } from 'date-fns'
 
 const downloadDats = (dats) => {
   var element = document.createElement('a')
@@ -11,7 +10,7 @@ const downloadDats = (dats) => {
   )
   element.setAttribute(
     'download',
-    `DATS_${format(new Date(), 'yyMMddHHmmss')}.json`
+    `DATS.json`
   )
 
   element.style.display = 'none'

--- a/src/model/formToDats.js
+++ b/src/model/formToDats.js
@@ -23,7 +23,10 @@ class FormToDats {
         if (c.type === 'Person' && Object.keys(c).includes('name')) {
           c.fullName = c.name
           delete c.name
-        } else if (c.type === 'Organization' && Object.keys(c).includes('fullName')) {
+        } else if (
+          c.type === 'Organization' &&
+          Object.keys(c).includes('fullName')
+        ) {
           c.name = c.fullName
           delete c.fullName
         }

--- a/src/model/formToDats.js
+++ b/src/model/formToDats.js
@@ -20,6 +20,13 @@ class FormToDats {
       }),
       creators: this.data.creators.map((creator) => {
         const c = creator
+        if (c.type === 'Person' && Object.keys(c).includes('name')) {
+          c.fullName = c.name
+          delete c.name
+        } else if (c.type === 'Organization' && Object.keys(c).includes('fullName')) {
+          c.name = c.fullName
+          delete c.fullName
+        }
         delete c.type
         delete c.role
         if (creator.role)


### PR DESCRIPTION
This PR fixes two things encountered while asking a user to edit a file automatically generated by the crawler into the DATS editor:
1. removes the date and time appended to the name of the DATS file to avoid any confusion of what needs to be uploaded. https://github.com/CONP-PCNO/conp-dataset/issues/678
2. fixes the encoding of the creator fields when they were initially generated by the crawler and encoded as organization but the user selects 'Person'. When the user select person, the `fullName` was encoded `name` by mistake. Added a few if statements to ensure that a Person will always have a `fullName` key and an organization will always have a `name` key