### PR TITLE
move species URI to identifier instead of identifierSource

### DIFF
--- a/src/model/datsToForm.js
+++ b/src/model/datsToForm.js
@@ -115,7 +115,7 @@ class DatsToForm {
             ...a,
             type:
               Object.keys(a).includes('identifier') &&
-              a.identifier.identifierSource.match(/taxonomy/)
+              a.identifier.identifier.match(/taxonomy/)
                 ? 'Species'
                 : 'Other Entity',
             name: a.name

--- a/src/model/formToDats.js
+++ b/src/model/formToDats.js
@@ -122,7 +122,8 @@ class FormToDats {
         if (i.type === 'Species' && Object.keys(species).includes(i.name)) {
           i.identifier = {
             identifier:
-              'https://www.ncbi.nlm.nih.gov/taxonomy/' + species[i.name]
+              'https://www.ncbi.nlm.nih.gov/taxonomy/' + species[i.name],
+            identifierSource: 'NCBI Taxonomy Database'
           }
         }
         delete i.type

--- a/src/model/formToDats.js
+++ b/src/model/formToDats.js
@@ -121,8 +121,7 @@ class FormToDats {
         }
         if (i.type === 'Species' && Object.keys(species).includes(i.name)) {
           i.identifier = {
-            identifier: species[i.name],
-            identifierSource:
+            identifier:
               'https://www.ncbi.nlm.nih.gov/taxonomy/' + species[i.name]
           }
         }


### PR DESCRIPTION
Updates the way species is encoded in the DATS GUI editor according to https://github.com/CONP-PCNO/conp-dataset/issues/712.

A.k.a. URI in `identifier` field instead of `identifierSource`